### PR TITLE
Refactor to use dedicated `Factory` to open database and split `DatabaseInterface` and internal `ProcessIoDatabase` implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ built on top of [ReactPHP](https://reactphp.org/).
 * [Usage](#usage)
   * [Factory](#factory)
     * [open()](#open)
-  * [Database](#database)
+  * [DatabaseInterface](#databaseinterface)
     * [exec()](#exec)
     * [query()](#query)
     * [quit()](#quit)
@@ -33,7 +33,7 @@ $factory = new Clue\React\SQLite\Factory($loop);
 
 $name = 'Alice';
 $factory->open('users.db')->then(
-    function (Clue\React\SQLite\Database $db) use ($name) {
+    function (Clue\React\SQLite\DatabaseInterface $db) use ($name) {
         $db->exec('CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY AUTOINCREMENT, bar STRING)');
 
         $db->query('INSERT INTO foo (bar) VALUES (?)', array($name))->then(
@@ -58,7 +58,7 @@ See also the [examples](examples).
 
 ### Factory
 
-The `Factory` is responsible for opening your [`Database`](#database) instance.
+The `Factory` is responsible for opening your [`DatabaseInterface`](#databaseinterface) instance.
 It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
 
 ```php
@@ -68,17 +68,17 @@ $factory = new Clue\React\SQLite\Factory($loop);
 
 #### open()
 
-The `open(string $filename, int $flags = null): PromiseInterface<Database>` method can be used to
+The `open(string $filename, int $flags = null): PromiseInterface<DatabaseInterface>` method can be used to
 open a new database connection for the given SQLite database file.
 
-This method returns a promise that will resolve with a `Database` on
+This method returns a promise that will resolve with a `DatabaseInterface` on
 success or will reject with an `Exception` on error. The SQLite extension
 is inherently blocking, so this method will spawn an SQLite worker process
 to run all SQLite commands and queries in a separate process without
 blocking the main process.
 
 ```php
-$factory->open('users.db')->then(function (Database $db) {
+$factory->open('users.db')->then(function (DatabaseInterface $db) {
     // database ready
     // $db->query('INSERT INTO users (name) VALUES ("test")');
     // $db->quit();
@@ -91,7 +91,7 @@ The optional `$flags` parameter is used to determine how to open the
 SQLite database. By default, open uses `SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE`.
 
 ```php
-$factory->open('users.db', SQLITE3_OPEN_READONLY)->then(function (Database $db) {
+$factory->open('users.db', SQLITE3_OPEN_READONLY)->then(function (DatabaseInterface $db) {
     // database ready (read-only)
     // $db->quit();
 }, function (Exception $e) {
@@ -99,9 +99,9 @@ $factory->open('users.db', SQLITE3_OPEN_READONLY)->then(function (Database $db) 
 });
 ```
 
-### Database
+### DatabaseInterface
 
-The `Database` class represents a connection that is responsible for
+The `DatabaseInterface` represents a connection that is responsible for
 comunicating with your SQLite database wrapper, managing the connection state
 and sending your database queries.
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ built on top of [ReactPHP](https://reactphp.org/).
 
 * [Quickstart example](#quickstart-example)
 * [Usage](#usage)
+  * [Factory](#factory)
+    * [open()](#open)
   * [Database](#database)
     * [exec()](#exec)
     * [query()](#query)
@@ -27,9 +29,10 @@ existing SQLite database file (or automatically create it on first run) and then
 
 ```php
 $loop = React\EventLoop\Factory::create();
+$factory = new Clue\React\SQLite\Factory($loop);
 
 $name = 'Alice';
-Clue\React\SQLite\Database::open($loop, 'users.db')->then(
+$factory->open('users.db')->then(
     function (Clue\React\SQLite\Database $db) use ($name) {
         $db->exec('CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY AUTOINCREMENT, bar STRING)');
 
@@ -53,15 +56,19 @@ See also the [examples](examples).
 
 ## Usage
 
-### Database
+### Factory
 
-The `Database` class represents a connection that is responsible for
-comunicating with your SQLite database wrapper, managing the connection state
-and sending your database queries.
+The `Factory` is responsible for opening your [`Database`](#database) instance.
+It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
+
+```php
+$loop = React\EventLoop\Factory::create();
+$factory = new Clue\React\SQLite\Factory($loop);
+```
 
 #### open()
 
-The static `open(LoopInterface $loop, string $filename, int $flags = null): PromiseInterface<Database>` method can be used to
+The `open(string $filename, int $flags = null): PromiseInterface<Database>` method can be used to
 open a new database connection for the given SQLite database file.
 
 This method returns a promise that will resolve with a `Database` on
@@ -71,7 +78,7 @@ to run all SQLite commands and queries in a separate process without
 blocking the main process.
 
 ```php
-Database::open($loop, 'users.db')->then(function (Database $db) {
+$factory->open('users.db')->then(function (Database $db) {
     // database ready
     // $db->query('INSERT INTO users (name) VALUES ("test")');
     // $db->quit();
@@ -84,13 +91,19 @@ The optional `$flags` parameter is used to determine how to open the
 SQLite database. By default, open uses `SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE`.
 
 ```php
-Database::open($loop, 'users.db', SQLITE3_OPEN_READONLY)->then(function (Database $db) {
+$factory->open('users.db', SQLITE3_OPEN_READONLY)->then(function (Database $db) {
     // database ready (read-only)
     // $db->quit();
 }, function (Exception $e) {
     echo 'Error: ' . $e->getMessage() . PHP_EOL;
 });
 ```
+
+### Database
+
+The `Database` class represents a connection that is responsible for
+comunicating with your SQLite database wrapper, managing the connection state
+and sending your database queries.
 
 #### exec()
 

--- a/examples/insert.php
+++ b/examples/insert.php
@@ -1,6 +1,6 @@
 <?php
 
-use Clue\React\SQLite\Database;
+use Clue\React\SQLite\DatabaseInterface;
 use Clue\React\SQLite\Factory;
 use Clue\React\SQLite\Result;
 
@@ -10,7 +10,7 @@ $loop = React\EventLoop\Factory::create();
 $factory = new Factory($loop);
 
 $n = isset($argv[1]) ? $argv[1] : 1;
-$factory->open('test.db')->then(function (Database $db) use ($n) {
+$factory->open('test.db')->then(function (DatabaseInterface $db) use ($n) {
     $db->exec('CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY AUTOINCREMENT, bar STRING)');
 
     for ($i = 0; $i < $n; ++$i) {

--- a/examples/insert.php
+++ b/examples/insert.php
@@ -1,15 +1,16 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\SQLite\Database;
+use Clue\React\SQLite\Factory;
 use Clue\React\SQLite\Result;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
+$loop = React\EventLoop\Factory::create();
+$factory = new Factory($loop);
 
 $n = isset($argv[1]) ? $argv[1] : 1;
-Database::open($loop, 'test.db')->then(function (Database $db) use ($n) {
+$factory->open('test.db')->then(function (Database $db) use ($n) {
     $db->exec('CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY AUTOINCREMENT, bar STRING)');
 
     for ($i = 0; $i < $n; ++$i) {

--- a/examples/search.php
+++ b/examples/search.php
@@ -1,6 +1,6 @@
 <?php
 
-use Clue\React\SQLite\Database;
+use Clue\React\SQLite\DatabaseInterface;
 use Clue\React\SQLite\Factory;
 use Clue\React\SQLite\Result;
 
@@ -10,7 +10,7 @@ $loop = React\EventLoop\Factory::create();
 $factory = new Factory($loop);
 
 $search = isset($argv[1]) ? $argv[1] : 'foo';
-$factory->open('test.db')->then(function (Database $db) use ($search){
+$factory->open('test.db')->then(function (DatabaseInterface $db) use ($search){
     $db->query('SELECT * FROM foo WHERE bar LIKE ?', ['%' . $search . '%'])->then(function (Result $result) {
         echo 'Found ' . count($result->rows) . ' rows: ' . PHP_EOL;
         echo implode("\t", $result->columns) . PHP_EOL;

--- a/examples/search.php
+++ b/examples/search.php
@@ -1,15 +1,16 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\SQLite\Database;
+use Clue\React\SQLite\Factory;
 use Clue\React\SQLite\Result;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = Factory::create();
+$loop = React\EventLoop\Factory::create();
+$factory = new Factory($loop);
 
 $search = isset($argv[1]) ? $argv[1] : 'foo';
-Database::open($loop, 'test.db')->then(function (Database $db) use ($search){
+$factory->open('test.db')->then(function (Database $db) use ($search){
     $db->query('SELECT * FROM foo WHERE bar LIKE ?', ['%' . $search . '%'])->then(function (Result $result) {
         echo 'Found ' . count($result->rows) . ' rows: ' . PHP_EOL;
         echo implode("\t", $result->columns) . PHP_EOL;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -4,13 +4,14 @@ namespace Clue\React\SQLite;
 
 use React\ChildProcess\Process;
 use React\EventLoop\LoopInterface;
+use Clue\React\SQLite\Io\ProcessIoDatabase;
 
 class Factory
 {
     private $loop;
 
     /**
-     * The `Factory` is responsible for opening your [`Database`](#database) instance.
+     * The `Factory` is responsible for opening your [`DatabaseInterface`](#databaseinterface) instance.
      * It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
      *
      * ```php
@@ -28,14 +29,14 @@ class Factory
     /**
      * Opens a new database connection for the given SQLite database file.
      *
-     * This method returns a promise that will resolve with a `Database` on
+     * This method returns a promise that will resolve with a `DatabaseInterface` on
      * success or will reject with an `Exception` on error. The SQLite extension
      * is inherently blocking, so this method will spawn an SQLite worker process
      * to run all SQLite commands and queries in a separate process without
      * blocking the main process.
      *
      * ```php
-     * $factory->open('users.db')->then(function (Database $db) {
+     * $factory->open('users.db')->then(function (DatabaseInterface $db) {
      *     // database ready
      *     // $db->query('INSERT INTO users (name) VALUES ("test")');
      *     // $db->quit();
@@ -48,7 +49,7 @@ class Factory
      * SQLite database. By default, open uses `SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE`.
      *
      * ```php
-     * $factory->open('users.db', SQLITE3_OPEN_READONLY)->then(function (Database $db) {
+     * $factory->open('users.db', SQLITE3_OPEN_READONLY)->then(function (DatabaseInterface $db) {
      *     // database ready (read-only)
      *     // $db->quit();
      * }, function (Exception $e) {
@@ -58,7 +59,7 @@ class Factory
      *
      * @param string $filename
      * @param ?int   $flags
-     * @return PromiseInterface<Database> Resolves with Database instance or rejects with Exception
+     * @return PromiseInterface<DatabaseInterface> Resolves with DatabaseInterface instance or rejects with Exception
      */
     public function open($filename, $flags = null)
     {
@@ -107,7 +108,7 @@ class Factory
         $process = new Process($command, null, null, $pipes);
         $process->start($this->loop);
 
-        $db = new Database($process);
+        $db = new ProcessIoDatabase($process);
         $args = array($filename);
         if ($flags !== null) {
             $args[] = $flags;

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Clue\React\SQLite;
+
+use React\ChildProcess\Process;
+use React\EventLoop\LoopInterface;
+
+class Factory
+{
+    private $loop;
+
+    /**
+     * The `Factory` is responsible for opening your [`Database`](#database) instance.
+     * It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
+     *
+     * ```php
+     * $loop = \React\EventLoop\Factory::create();
+     * $factory = new Factory($loop);
+     * ```
+     *
+     * @param LoopInterface $loop
+     */
+    public function __construct(LoopInterface $loop)
+    {
+        $this->loop = $loop;
+    }
+
+    /**
+     * Opens a new database connection for the given SQLite database file.
+     *
+     * This method returns a promise that will resolve with a `Database` on
+     * success or will reject with an `Exception` on error. The SQLite extension
+     * is inherently blocking, so this method will spawn an SQLite worker process
+     * to run all SQLite commands and queries in a separate process without
+     * blocking the main process.
+     *
+     * ```php
+     * $factory->open('users.db')->then(function (Database $db) {
+     *     // database ready
+     *     // $db->query('INSERT INTO users (name) VALUES ("test")');
+     *     // $db->quit();
+     * }, function (Exception $e) {
+     *     echo 'Error: ' . $e->getMessage() . PHP_EOL;
+     * });
+     * ```
+     *
+     * The optional `$flags` parameter is used to determine how to open the
+     * SQLite database. By default, open uses `SQLITE3_OPEN_READWRITE | SQLITE3_OPEN_CREATE`.
+     *
+     * ```php
+     * $factory->open('users.db', SQLITE3_OPEN_READONLY)->then(function (Database $db) {
+     *     // database ready (read-only)
+     *     // $db->quit();
+     * }, function (Exception $e) {
+     *     echo 'Error: ' . $e->getMessage() . PHP_EOL;
+     * });
+     * ```
+     *
+     * @param string $filename
+     * @param ?int   $flags
+     * @return PromiseInterface<Database> Resolves with Database instance or rejects with Exception
+     */
+    public function open($filename, $flags = null)
+    {
+        $command = 'exec ' . \escapeshellarg(\PHP_BINARY) . ' ' . \escapeshellarg(__DIR__ . '/../res/sqlite-worker.php');
+
+        // Try to get list of all open FDs (Linux/Mac and others)
+        $fds = @\scandir('/dev/fd');
+
+        // Otherwise try temporarily duplicating file descriptors in the range 0-1024 (FD_SETSIZE).
+        // This is known to work on more exotic platforms and also inside chroot
+        // environments without /dev/fd. Causes many syscalls, but still rather fast.
+        // @codeCoverageIgnoreStart
+        if ($fds === false) {
+            $fds = array();
+            for ($i = 0; $i <= 1024; ++$i) {
+                $copy = @\fopen('php://fd/' . $i, 'r');
+                if ($copy !== false) {
+                    $fds[] = $i;
+                    \fclose($copy);
+                }
+            }
+        }
+        // @codeCoverageIgnoreEnd
+
+        // launch process with default STDIO pipes
+        $pipes = array(
+            array('pipe', 'r'),
+            array('pipe', 'w'),
+            array('pipe', 'w')
+        );
+
+        // do not inherit open FDs by explicitly overwriting existing FDs with dummy files
+        // additionally, close all dummy files in the child process again
+        foreach ($fds as $fd) {
+            if ($fd > 2) {
+                $pipes[$fd] = array('file', '/dev/null', 'r');
+                $command .= ' ' . $fd . '>&-';
+            }
+        }
+
+        // default `sh` only accepts single-digit FDs, so run in bash if needed
+        if ($fds && \max($fds) > 9) {
+            $command = 'exec bash -c ' . \escapeshellarg($command);
+        }
+
+        $process = new Process($command, null, null, $pipes);
+        $process->start($this->loop);
+
+        $db = new Database($process);
+        $args = array($filename);
+        if ($flags !== null) {
+            $args[] = $flags;
+        }
+
+        return $db->send('open', $args)->then(function () use ($db) {
+            return $db;
+        }, function ($e) use ($db) {
+            $db->close();
+            throw $e;
+        });
+    }
+}

--- a/src/Io/ProcessIoDatabase.php
+++ b/src/Io/ProcessIoDatabase.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Clue\React\SQLite\Io;
+
+use Clue\React\NDJson\Decoder;
+use Clue\React\SQLite\DatabaseInterface;
+use Clue\React\SQLite\Result;
+use Evenement\EventEmitter;
+use React\ChildProcess\Process;
+use React\Promise\Deferred;
+
+/**
+ * The internal `ProcessDatabase` class is responsible for communicating with
+ * your SQLite database process via process I/O pipes, managing the connection
+ * state and sending your database queries.
+ *
+ * @internal see DatabaseInterface instead
+ * @see DatabaseInterface
+ */
+class ProcessIoDatabase extends EventEmitter implements DatabaseInterface
+{
+    private $process;
+    private $pending = array();
+    private $id = 0;
+    private $closed = false;
+
+    /**
+     * @internal see Factory instead
+     * @see \Clue\React\SQLite\Factory
+     * @param Process $process
+     */
+    public function __construct(Process $process)
+    {
+        $this->process = $process;
+
+        $in = new Decoder($process->stdout, true, 512, 0, 16 * 1024 * 1024);
+        $in->on('data', function ($data) use ($in) {
+            if (!isset($data['id']) || !isset($this->pending[$data['id']])) {
+                $this->emit('error', array(new \RuntimeException('Invalid message received')));
+                $in->close();
+                return;
+            }
+
+            /* @var Deferred $deferred */
+            $deferred = $this->pending[$data['id']];
+            unset($this->pending[$data['id']]);
+
+            if (isset($data['error'])) {
+                $deferred->reject(new \RuntimeException(
+                    isset($data['error']['message']) ? $data['error']['message'] : 'Unknown error',
+                    isset($data['error']['code']) ? $data['error']['code'] : 0
+                ));
+            } else {
+                $deferred->resolve($data['result']);
+            }
+        });
+        $in->on('error', function (\Exception $e) {
+            $this->emit('error', array($e));
+            $this->close();
+        });
+        $in->on('close', function () {
+            $this->close();
+        });
+    }
+
+    public function exec($sql)
+    {
+        return $this->send('exec', array($sql))->then(function ($data) {
+            $result = new Result();
+            $result->changed = $data['changed'];
+            $result->insertId = $data['insertId'];
+
+            return $result;
+        });
+    }
+
+    public function query($sql, array $params = array())
+    {
+        return $this->send('query', array($sql, $params))->then(function ($data) {
+            $result = new Result();
+            $result->changed = $data['changed'];
+            $result->insertId = $data['insertId'];
+            $result->columns = $data['columns'];
+            $result->rows = $data['rows'];
+
+            return $result;
+        });
+    }
+
+    public function quit()
+    {
+        $promise = $this->send('close', array());
+
+        $this->process->stdin->end();
+
+        return $promise;
+    }
+
+    public function close()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+        foreach ($this->process->pipes as $pipe) {
+            $pipe->close();
+        }
+        $this->process->terminate();
+
+        foreach ($this->pending as $one) {
+            $one->reject(new \RuntimeException('Database closed'));
+        }
+        $this->pending = array();
+
+        $this->emit('close');
+        $this->removeAllListeners();
+    }
+
+    /** @internal */
+    public function send($method, array $params)
+    {
+        if (!$this->process->stdin->isWritable()) {
+            return \React\Promise\reject(new \RuntimeException('Database closed'));
+        }
+
+        $id = ++$this->id;
+        $this->process->stdin->write(\json_encode(array(
+            'id' => $id,
+            'method' => $method,
+            'params' => $params
+        ), \JSON_UNESCAPED_SLASHES) . "\n");
+
+        $deferred = new Deferred();
+        $this->pending[$id] = $deferred;
+
+        return $deferred->promise();
+    }
+}

--- a/tests/FunctionalDatabaseTest.php
+++ b/tests/FunctionalDatabaseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-use Clue\React\SQLite\Database;
+use Clue\React\SQLite\DatabaseInterface;
 use Clue\React\SQLite\Factory;
 use Clue\React\SQLite\Result;
 use PHPUnit\Framework\TestCase;
@@ -15,10 +15,10 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $promise->then(
-            $this->expectCallableOnceWith($this->isInstanceOf('Clue\React\SQLite\Database'))
+            $this->expectCallableOnceWith($this->isInstanceOf('Clue\React\SQLite\DatabaseInterface'))
         );
 
-        $promise->then(function (Database $db) {
+        $promise->then(function (DatabaseInterface $db) {
             $db->close();
         });
 
@@ -33,10 +33,10 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $promise->then(
-            $this->expectCallableOnceWith($this->isInstanceOf('Clue\React\SQLite\Database'))
+            $this->expectCallableOnceWith($this->isInstanceOf('Clue\React\SQLite\DatabaseInterface'))
         );
 
-        $promise->then(function (Database $db) {
+        $promise->then(function (DatabaseInterface $db) {
             $db->quit();
         });
 
@@ -64,7 +64,7 @@ class FunctionalDatabaseTest extends TestCase
         $this->assertTrue(is_resource($server));
         fclose($server);
 
-        $promise->then(function (Database $db) {
+        $promise->then(function (DatabaseInterface $db) {
             $db->close();
         });
 
@@ -109,7 +109,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnce();
-        $promise->then(function (Database $db) use ($once){
+        $promise->then(function (DatabaseInterface $db) use ($once){
             $db->quit()->then($once);
         });
 
@@ -130,7 +130,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnce();
-        $promise->then(function (Database $db) use ($once){
+        $promise->then(function (DatabaseInterface $db) use ($once){
             $db->quit()->then($once);
         });
 
@@ -149,7 +149,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnce();
-        $promise->then(function (Database $db) use ($once){
+        $promise->then(function (DatabaseInterface $db) use ($once){
             $db->quit();
             $db->quit()->then(null, $once);
         });
@@ -165,7 +165,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $data = null;
-        $promise->then(function (Database $db) use (&$data){
+        $promise->then(function (DatabaseInterface $db) use (&$data){
             $db->query('SELECT 1 AS value')->then(function (Result $result) use (&$data) {
                 $data = $result->rows;
             });
@@ -186,7 +186,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $data = null;
-        $promise->then(function (Database $db) use (&$data){
+        $promise->then(function (DatabaseInterface $db) use (&$data){
             $db->query('SELECT "hellö" AS value')->then(function (Result $result) use (&$data) {
                 $data = $result->rows;
             });
@@ -207,7 +207,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $data = null;
-        $promise->then(function (Database $db) use (&$data){
+        $promise->then(function (DatabaseInterface $db) use (&$data){
             $db->query('SELECT ? AS value', array(1))->then(function (Result $result) use (&$data) {
                 $data = $result->rows;
             });
@@ -228,7 +228,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $data = null;
-        $promise->then(function (Database $db) use (&$data){
+        $promise->then(function (DatabaseInterface $db) use (&$data){
             $db->query('SELECT :value AS value', array('value' => 1))->then(function (Result $result) use (&$data) {
                 $data = $result->rows;
             });
@@ -249,7 +249,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $data = null;
-        $promise->then(function (Database $db) use (&$data){
+        $promise->then(function (DatabaseInterface $db) use (&$data){
             $db->query('SELECT ? AS value', array(null))->then(function (Result $result) use (&$data) {
                 $data = $result->rows;
             });
@@ -270,7 +270,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException'));
-        $promise->then(function (Database $db) use ($once){
+        $promise->then(function (DatabaseInterface $db) use ($once){
             $db->query('nope')->then(null, $once);
 
             $db->quit();
@@ -287,7 +287,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException'));
-        $promise->then(function (Database $db) use ($once){
+        $promise->then(function (DatabaseInterface $db) use ($once){
             $db->query('SELECT 1')->then(null, $once);
 
             $db->close();
@@ -304,7 +304,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $data = 'n/a';
-        $promise->then(function (Database $db) use (&$data){
+        $promise->then(function (DatabaseInterface $db) use (&$data){
             $db->exec('CREATE TABLE foo (bar STRING)')->then(function (Result $result) use (&$data) {
                 $data = $result->rows;
             });
@@ -325,7 +325,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException'));
-        $promise->then(function (Database $db) use ($once){
+        $promise->then(function (DatabaseInterface $db) use ($once){
             $db->exec('USE a')->then(null, $once);
 
             $db->close();
@@ -342,7 +342,7 @@ class FunctionalDatabaseTest extends TestCase
         $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException'));
-        $promise->then(function (Database $db) use ($once){
+        $promise->then(function (DatabaseInterface $db) use ($once){
             $db->close();
             $db->exec('USE a')->then(null, $once);
         });

--- a/tests/FunctionalDatabaseTest.php
+++ b/tests/FunctionalDatabaseTest.php
@@ -1,17 +1,18 @@
 <?php
 
-use React\EventLoop\Factory;
 use Clue\React\SQLite\Database;
-use PHPUnit\Framework\TestCase;
+use Clue\React\SQLite\Factory;
 use Clue\React\SQLite\Result;
+use PHPUnit\Framework\TestCase;
 
 class FunctionalDatabaseTest extends TestCase
 {
     public function testOpenMemoryDatabaseResolvesWithDatabaseAndRunsUntilClose()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $promise->then(
             $this->expectCallableOnceWith($this->isInstanceOf('Clue\React\SQLite\Database'))
@@ -26,9 +27,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testOpenMemoryDatabaseResolvesWithDatabaseAndRunsUntilQuit()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $promise->then(
             $this->expectCallableOnceWith($this->isInstanceOf('Clue\React\SQLite\Database'))
@@ -50,9 +52,10 @@ class FunctionalDatabaseTest extends TestCase
             $this->markTestSkipped('Platform does not prevent binding to same address (Windows?)');
         }
 
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         // close server and ensure we can start a new server on the previous address
         // the pending SQLite process should not inherit the existing server socket
@@ -70,9 +73,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testOpenInvalidPathRejects()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, '/dev/foo/bar');
+        $promise = $factory->open('/dev/foo/bar');
 
         $promise->then(
             null,
@@ -84,9 +88,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testOpenInvalidFlagsRejects()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, '::memory::', SQLITE3_OPEN_READONLY);
+        $promise = $factory->open('::memory::', SQLITE3_OPEN_READONLY);
 
         $promise->then(
             null,
@@ -98,9 +103,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testQuitResolvesAndRunsUntilQuit()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnce();
         $promise->then(function (Database $db) use ($once){
@@ -118,9 +124,10 @@ class FunctionalDatabaseTest extends TestCase
             $servers[] = stream_socket_server('tcp://127.0.0.1:0');
         }
 
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnce();
         $promise->then(function (Database $db) use ($once){
@@ -136,9 +143,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testQuitTwiceWillRejectSecondCall()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnce();
         $promise->then(function (Database $db) use ($once){
@@ -151,9 +159,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testQueryIntegerResolvesWithResultWithTypeIntegerAndRunsUntilQuit()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $data = null;
         $promise->then(function (Database $db) use (&$data){
@@ -171,9 +180,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testQueryStringResolvesWithResultWithTypeStringAndRunsUntilQuit()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $data = null;
         $promise->then(function (Database $db) use (&$data){
@@ -191,9 +201,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testQueryIntegerPlaceholderPositionalResolvesWithResultWithTypeIntegerAndRunsUntilQuit()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $data = null;
         $promise->then(function (Database $db) use (&$data){
@@ -211,9 +222,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testQueryIntegerPlaceholderNamedResolvesWithResultWithTypeIntegerAndRunsUntilQuit()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $data = null;
         $promise->then(function (Database $db) use (&$data){
@@ -231,9 +243,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testQueryNullPlaceholderPositionalResolvesWithResultWithTypeNullAndRunsUntilQuit()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $data = null;
         $promise->then(function (Database $db) use (&$data){
@@ -251,9 +264,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testQueryRejectsWhenQueryIsInvalid()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException'));
         $promise->then(function (Database $db) use ($once){
@@ -267,9 +281,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testQueryRejectsWhenClosedImmediately()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException'));
         $promise->then(function (Database $db) use ($once){
@@ -283,9 +298,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testExecCreateTableResolvesWithResultWithoutRows()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $data = 'n/a';
         $promise->then(function (Database $db) use (&$data){
@@ -303,9 +319,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testExecRejectsWhenClosedImmediately()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException'));
         $promise->then(function (Database $db) use ($once){
@@ -319,9 +336,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function testExecRejectsWhenAlreadyClosed()
     {
-        $loop = Factory::create();
+        $loop = React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
 
-        $promise = Database::open($loop, ':memory:');
+        $promise = $factory->open(':memory:');
 
         $once = $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException'));
         $promise->then(function (Database $db) use ($once){

--- a/tests/Io/DatabaseTest.php
+++ b/tests/Io/DatabaseTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use Clue\React\SQLite\Database;
+use Clue\React\SQLite\DatabaseInterface;
 use React\Stream\ThroughStream;
 
 class DatabaseTest extends TestCase
@@ -17,8 +17,8 @@ class DatabaseTest extends TestCase
         $process->stdin = $stdin;
         $process->stdout = $stdout;
 
-        /* @var Database $database */
-        $ref = new ReflectionClass('Clue\React\SQLite\Database');
+        /* @var DatabaseInterface $database */
+        $ref = new ReflectionClass('Clue\React\SQLite\Io\ProcessIoDatabase');
         $database = $ref->newInstanceWithoutConstructor();
 
         $ref = new ReflectionMethod($database, '__construct');
@@ -42,8 +42,8 @@ class DatabaseTest extends TestCase
         $process->stdin = $stdin;
         $process->stdout = $stdout;
 
-        /* @var Database $database */
-        $ref = new ReflectionClass('Clue\React\SQLite\Database');
+        /* @var DatabaseInterface $database */
+        $ref = new ReflectionClass('Clue\React\SQLite\Io\ProcessIoDatabase');
         $database = $ref->newInstanceWithoutConstructor();
 
         $ref = new ReflectionMethod($database, '__construct');
@@ -65,8 +65,8 @@ class DatabaseTest extends TestCase
         $process = $this->getMockBuilder('React\ChildProcess\Process')->disableOriginalConstructor()->getMock();
         $process->stdin = $stdin;
 
-        /* @var Database $database */
-        $ref = new ReflectionClass('Clue\React\SQLite\Database');
+        /* @var DatabaseInterface $database */
+        $ref = new ReflectionClass('Clue\React\SQLite\Io\ProcessIoDatabase');
         $database = $ref->newInstanceWithoutConstructor();
 
         $ref = new ReflectionProperty($database, 'process');
@@ -87,8 +87,8 @@ class DatabaseTest extends TestCase
         $process = $this->getMockBuilder('React\ChildProcess\Process')->disableOriginalConstructor()->getMock();
         $process->stdin = $stdin;
 
-        /* @var Database $database */
-        $ref = new ReflectionClass('Clue\React\SQLite\Database');
+        /* @var DatabaseInterface $database */
+        $ref = new ReflectionClass('Clue\React\SQLite\Io\ProcessIoDatabase');
         $database = $ref->newInstanceWithoutConstructor();
 
         $ref = new ReflectionProperty($database, 'process');
@@ -110,8 +110,8 @@ class DatabaseTest extends TestCase
         $process = $this->getMockBuilder('React\ChildProcess\Process')->disableOriginalConstructor()->getMock();
         $process->stdin = $stdin;
 
-        /* @var Database $database */
-        $ref = new ReflectionClass('Clue\React\SQLite\Database');
+        /* @var DatabaseInterface $database */
+        $ref = new ReflectionClass('Clue\React\SQLite\Io\ProcessIoDatabase');
         $database = $ref->newInstanceWithoutConstructor();
 
         $ref = new ReflectionProperty($database, 'process');
@@ -132,8 +132,8 @@ class DatabaseTest extends TestCase
         $process = $this->getMockBuilder('React\ChildProcess\Process')->disableOriginalConstructor()->getMock();
         $process->stdin = $stdin;
 
-        /* @var Database $database */
-        $ref = new ReflectionClass('Clue\React\SQLite\Database');
+        /* @var DatabaseInterface $database */
+        $ref = new ReflectionClass('Clue\React\SQLite\Io\ProcessIoDatabase');
         $database = $ref->newInstanceWithoutConstructor();
 
         $ref = new ReflectionProperty($database, 'process');
@@ -157,8 +157,8 @@ class DatabaseTest extends TestCase
         $process->expects($this->once())->method('terminate');
         $process->pipes = array($stdin, $stdout);
 
-        /* @var Database $database */
-        $ref = new ReflectionClass('Clue\React\SQLite\Database');
+        /* @var DatabaseInterface $database */
+        $ref = new ReflectionClass('Clue\React\SQLite\Io\ProcessIoDatabase');
         $database = $ref->newInstanceWithoutConstructor();
 
         $ref = new ReflectionProperty($database, 'process');
@@ -181,8 +181,8 @@ class DatabaseTest extends TestCase
         $process->expects($this->once())->method('terminate');
         $process->pipes = array($stdin, $stdout);
 
-        /* @var Database $database */
-        $ref = new ReflectionClass('Clue\React\SQLite\Database');
+        /* @var DatabaseInterface $database */
+        $ref = new ReflectionClass('Clue\React\SQLite\Io\ProcessIoDatabase');
         $database = $ref->newInstanceWithoutConstructor();
 
         $ref = new ReflectionProperty($database, 'process');


### PR DESCRIPTION
This is done to achieve better separation of concerns in preparation for creating multiple database launchers and database communication implementations for Windows support in the future.

Refs #3