### PR TITLE
Support float values without fraction on legacy PHP < 5.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,6 @@ characters will be mapped to `TEXT`, binary strings will be mapped to
 does not have a native boolean type, so `true` and `false` will be mapped
 to integer values `1` and `0` respectively.
 
-> Legacy PHP: Note that on legacy PHP < 5.6.6, a `float` without a
-  fraction (such as `1.0`) may end up as an `integer` instead. You're
-  highly recommended to use a supported PHP version or you may have to
-  use explicit SQL casts to work around this.
-
 #### quit()
 
 The `quit(): PromiseInterface<void, Exception>` method can be used to

--- a/src/DatabaseInterface.php
+++ b/src/DatabaseInterface.php
@@ -145,11 +145,6 @@ interface DatabaseInterface extends EventEmitterInterface
      * does not have a native boolean type, so `true` and `false` will be mapped
      * to integer values `1` and `0` respectively.
      *
-     * > Legacy PHP: Note that on legacy PHP < 5.6.6, a `float` without a
-     *   fraction (such as `1.0`) may end up as an `integer` instead. You're
-     *   highly recommended to use a supported PHP version or you may have to
-     *   use explicit SQL casts to work around this.
-     *
      * @param string $sql    SQL statement
      * @param array  $params Parameters which should be bound to query
      * @return PromiseInterface<Result> Resolves with Result instance or rejects with Exception

--- a/src/Io/ProcessIoDatabase.php
+++ b/src/Io/ProcessIoDatabase.php
@@ -80,6 +80,8 @@ class ProcessIoDatabase extends EventEmitter implements DatabaseInterface
         foreach ($params as &$value) {
             if (\is_string($value) && \preg_match('/[\x00-\x08\x11\x12\x14-\x1f\x7f]/u', $value) !== 0) {
                 $value = ['base64' => \base64_encode($value)];
+            } elseif (\is_float($value)) {
+                $value = ['float' => $value];
             }
         }
 
@@ -95,6 +97,8 @@ class ProcessIoDatabase extends EventEmitter implements DatabaseInterface
                 foreach ($row as &$value) {
                     if (isset($value['base64'])) {
                         $value = \base64_decode($value['base64']);
+                    } elseif (isset($value['float'])) {
+                        $value = (float)$value['float'];
                     }
                 }
                 $result->rows[] = $row;
@@ -150,7 +154,7 @@ class ProcessIoDatabase extends EventEmitter implements DatabaseInterface
             'id' => $id,
             'method' => $method,
             'params' => $params
-        ), \JSON_UNESCAPED_SLASHES | (\PHP_VERSION_ID >= 50606 ? JSON_PRESERVE_ZERO_FRACTION : 0)) . "\n");
+        ), \JSON_UNESCAPED_SLASHES) . "\n");
 
         $deferred = new Deferred();
         $this->pending[$id] = $deferred;

--- a/tests/FunctionalDatabaseTest.php
+++ b/tests/FunctionalDatabaseTest.php
@@ -298,15 +298,12 @@ class FunctionalDatabaseTest extends TestCase
             [
                 ['42', 42],
                 ['2.5', 2.5],
+                ['1.0', 1.0],
                 ['null', null],
                 ['"hello"', 'hello'],
                 ['"hellö"', 'hellö'],
                 ['X\'01020300\'', "\x01\x02\x03\x00"],
                 ['X\'3FF3\'', "\x3f\xf3"]
-            ],
-            (PHP_VERSION_ID < 50606) ? [] : [
-                // preserving zero fractions is only supported as of PHP 5.6.6
-                ['1.0', 1.0]
             ],
             (SQLite3::version()['versionNumber'] < 3023000) ? [] : [
                 // boolean identifiers exist only as of SQLite 3.23.0 (2018-04-02)
@@ -345,25 +342,20 @@ class FunctionalDatabaseTest extends TestCase
 
     public function provideDataWillBeReturnedWithType()
     {
-        return array_merge(
-            [
-                [0, 'INTEGER'],
-                [1, 'INTEGER'],
-                [1.5, 'REAL'],
-                [null, 'NULL'],
-                ['hello', 'TEXT'],
-                ['hellö', 'TEXT'],
-                ["hello\tworld\r\n", 'TEXT'],
-                [utf8_decode('hello wörld!'), 'BLOB'],
-                ["hello\x7fö", 'BLOB'],
-                ["\x03\x02\x001", 'BLOB'],
-                ["a\000b", 'BLOB']
-            ],
-            (PHP_VERSION_ID < 50606) ? [] : [
-                // preserving zero fractions is only supported as of PHP 5.6.6
-                [1.0, 'REAL']
-            ]
-        );
+        return [
+            [0, 'INTEGER'],
+            [1, 'INTEGER'],
+            [1.5, 'REAL'],
+            [1.0, 'REAL'],
+            [null, 'NULL'],
+            ['hello', 'TEXT'],
+            ['hellö', 'TEXT'],
+            ["hello\tworld\r\n", 'TEXT'],
+            [utf8_decode('hello wörld!'), 'BLOB'],
+            ["hello\x7fö", 'BLOB'],
+            ["\x03\x02\x001", 'BLOB'],
+            ["a\000b", 'BLOB']
+        ];
     }
 
     /**
@@ -418,16 +410,10 @@ class FunctionalDatabaseTest extends TestCase
 
     public function provideDataWillBeReturnedWithOtherType()
     {
-        return array_merge(
-            [
-                [true, 1],
-                [false, 0],
-            ],
-            (PHP_VERSION_ID >= 50606) ? [] : [
-                // preserving zero fractions is supported as of PHP 5.6.6, otherwise cast to int
-                [1.0, 1]
-            ]
-        );
+        return [
+            [true, 1],
+            [false, 0],
+        ];
     }
 
     /**


### PR DESCRIPTION
Builds on top of #16 and #14