### PR TITLE
Add new `loadLazy()` method to connect only on demand and implement "idle" timeout to close underlying connection when unused.

### DIFF
--- a/examples/insert.php
+++ b/examples/insert.php
@@ -1,6 +1,5 @@
 <?php
 
-use Clue\React\SQLite\DatabaseInterface;
 use Clue\React\SQLite\Factory;
 use Clue\React\SQLite\Result;
 
@@ -10,16 +9,17 @@ $loop = React\EventLoop\Factory::create();
 $factory = new Factory($loop);
 
 $n = isset($argv[1]) ? $argv[1] : 1;
-$factory->open('test.db')->then(function (DatabaseInterface $db) use ($n) {
-    $db->exec('CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY AUTOINCREMENT, bar STRING)');
+$db = $factory->openLazy('test.db');
 
-    for ($i = 0; $i < $n; ++$i) {
-        $db->exec("INSERT INTO foo (bar) VALUES ('This is a test')")->then(function (Result $result) {
-            echo 'New row ' . $result->insertId . PHP_EOL;
-        });
-    }
+$promise = $db->exec('CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY AUTOINCREMENT, bar STRING)');
+$promise->then(null, 'printf');
 
-    $db->quit();
-}, 'printf');
+for ($i = 0; $i < $n; ++$i) {
+    $db->exec("INSERT INTO foo (bar) VALUES ('This is a test')")->then(function (Result $result) {
+        echo 'New row ' . $result->insertId . PHP_EOL;
+    });
+}
+
+$db->quit();
 
 $loop->run();

--- a/examples/search.php
+++ b/examples/search.php
@@ -10,15 +10,15 @@ $loop = React\EventLoop\Factory::create();
 $factory = new Factory($loop);
 
 $search = isset($argv[1]) ? $argv[1] : 'foo';
-$factory->open('test.db')->then(function (DatabaseInterface $db) use ($search){
-    $db->query('SELECT * FROM foo WHERE bar LIKE ?', ['%' . $search . '%'])->then(function (Result $result) {
-        echo 'Found ' . count($result->rows) . ' rows: ' . PHP_EOL;
-        echo implode("\t", $result->columns) . PHP_EOL;
-        foreach ($result->rows as $row) {
-            echo implode("\t", $row) . PHP_EOL;
-        }
-    }, 'printf');
-    $db->quit();
+$db = $factory->openLazy('test.db');
+
+$db->query('SELECT * FROM foo WHERE bar LIKE ?', ['%' . $search . '%'])->then(function (Result $result) {
+    echo 'Found ' . count($result->rows) . ' rows: ' . PHP_EOL;
+    echo implode("\t", $result->columns) . PHP_EOL;
+    foreach ($result->rows as $row) {
+        echo implode("\t", $row) . PHP_EOL;
+    }
 }, 'printf');
+$db->quit();
 
 $loop->run();

--- a/src/Io/LazyDatabase.php
+++ b/src/Io/LazyDatabase.php
@@ -1,0 +1,174 @@
+<?php
+
+namespace Clue\React\SQLite\Io;
+
+use Clue\React\SQLite\DatabaseInterface;
+use Clue\React\SQLite\Factory;
+use Evenement\EventEmitter;
+use React\EventLoop\LoopInterface;
+
+/**
+ * @internal
+ */
+class LazyDatabase extends EventEmitter implements DatabaseInterface
+{
+    private $filename;
+    private $flags;
+    /** @var Factory */
+    private $factory;
+    private $loop;
+
+    private $closed = false;
+    /** @var ?\React\Promise\PromiseInterface */
+    private $promise;
+    private $idlePeriod = 60.0;
+    /** @var ?\React\EventLoop\TimerInterface */
+    private $idleTimer;
+    private $pending = 0;
+
+    public function __construct($target, $flags, array $options, Factory $factory, LoopInterface $loop)
+    {
+        $this->filename = $target;
+        $this->flags = $flags;
+        $this->factory = $factory;
+        $this->loop = $loop;
+
+        if (isset($options['idle'])) {
+            $this->idlePeriod = (float)$options['idle'];
+        }
+    }
+
+    /**
+     * @return \React\Promise\PromiseInterface
+     */
+    private function db()
+    {
+        if ($this->promise !== null) {
+            return $this->promise;
+        }
+
+        if ($this->closed) {
+            return \React\Promise\reject(new \RuntimeException('Connection closed'));
+        }
+
+        $this->promise = $promise = $this->factory->open($this->filename, $this->flags);
+        $promise->then(function (DatabaseInterface $db) {
+            // connection completed => remember only until closed
+            $db->on('close', function () {
+                $this->promise = null;
+
+                if ($this->idleTimer !== null) {
+                    $this->loop->cancelTimer($this->idleTimer);
+                    $this->idleTimer = null;
+                }
+            });
+        }, function () {
+            // connection failed => discard connection attempt
+            $this->promise = null;
+        });
+
+        return $promise;
+    }
+
+    public function exec($sql)
+    {
+        return $this->db()->then(function (DatabaseInterface $db) use ($sql) {
+            $this->awake();
+            return $db->exec($sql)->then(
+                function ($result) {
+                    $this->idle();
+                    return $result;
+                },
+                function ($error) {
+                    $this->idle();
+                    throw $error;
+                }
+            );
+        });
+    }
+
+    public function query($sql, array $params = [])
+    {
+        return $this->db()->then(function (DatabaseInterface $db) use ($sql, $params) {
+            $this->awake();
+            return $db->query($sql, $params)->then(
+                function ($result) {
+                    $this->idle();
+                    return $result;
+                },
+                function ($error) {
+                    $this->idle();
+                    throw $error;
+                }
+            );
+        });
+    }
+
+    public function quit()
+    {
+        if ($this->promise === null && !$this->closed) {
+            $this->close();
+            return \React\Promise\resolve();
+        }
+
+        return $this->db()->then(function (DatabaseInterface $db) {
+            $db->on('close', function () {
+                $this->close();
+            });
+            return $db->quit();
+        });
+    }
+
+    public function close()
+    {
+        if ($this->closed) {
+            return;
+        }
+
+        $this->closed = true;
+
+        // either close active connection or cancel pending connection attempt
+        if ($this->promise !== null) {
+            $this->promise->then(function (DatabaseInterface $db) {
+                $db->close();
+            });
+            if ($this->promise !== null) {
+                $this->promise->cancel();
+                $this->promise = null;
+            }
+        }
+
+        if ($this->idleTimer !== null) {
+            $this->loop->cancelTimer($this->idleTimer);
+            $this->idleTimer = null;
+        }
+
+        $this->emit('close');
+        $this->removeAllListeners();
+    }
+
+    private function awake()
+    {
+        ++$this->pending;
+
+        if ($this->idleTimer !== null) {
+            $this->loop->cancelTimer($this->idleTimer);
+            $this->idleTimer = null;
+        }
+    }
+
+    private function idle()
+    {
+        --$this->pending;
+
+        if ($this->pending < 1 && $this->idlePeriod >= 0) {
+            $this->idleTimer = $this->loop->addTimer($this->idlePeriod, function () {
+                $this->promise->then(function (DatabaseInterface $db) {
+                    $db->close();
+                });
+                $this->promise = null;
+                $this->idleTimer = null;
+            });
+        }
+    }
+}

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use Clue\React\SQLite\Factory;
+
+class FactoryTest extends TestCase
+{
+    public function testLoadLazyReturnsDatabaseImmediately()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $factory = new Factory($loop);
+
+        $db = $factory->openLazy(':memory:');
+
+        $this->assertInstanceOf('Clue\React\SQLite\DatabaseInterface', $db);
+    }
+
+    public function testLoadLazyWithIdleOptionsReturnsDatabaseWithIdleTimeApplied()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $factory = new Factory($loop);
+
+        $db = $factory->openLazy(':memory:', null, ['idle' => 10.0]);
+
+        $ref = new ReflectionProperty($db, 'idlePeriod');
+        $ref->setAccessible(true);
+        $value = $ref->getValue($db);
+
+        $this->assertEquals(10.0, $value);
+    }
+}

--- a/tests/Io/LazyDatabaseTest.php
+++ b/tests/Io/LazyDatabaseTest.php
@@ -1,0 +1,666 @@
+<?php
+
+namespace Clue\Tests\React\Redis;
+
+use Clue\React\SQLite\Io\LazyDatabase;
+use PHPUnit\Framework\TestCase;
+use React\Promise\Deferred;
+use React\Promise\Promise;
+
+class LazyDatabaseTest extends TestCase
+{
+    private $factory;
+    private $loop;
+    private $db;
+
+    public function setUp()
+    {
+        $this->factory = $this->getMockBuilder('Clue\React\SQLite\Factory')->disableOriginalConstructor()->getMock();
+        $this->loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+
+        $this->db = new LazyDatabase('localhost', null, [], $this->factory, $this->loop);
+    }
+
+    public function testExecWillCreateUnderlyingDatabaseAndReturnPendingPromise()
+    {
+        $promise = new Promise(function () { });
+        $this->factory->expects($this->once())->method('open')->willReturn($promise);
+
+        $this->loop->expects($this->never())->method('addTimer');
+
+        $promise = $this->db->exec('CREATE');
+
+        $promise->then($this->expectCallableNever());
+    }
+
+    public function testExecTwiceWillCreateOnceUnderlyingDatabase()
+    {
+        $promise = new Promise(function () { });
+        $this->factory->expects($this->once())->method('open')->willReturn($promise);
+
+        $this->db->exec('CREATE');
+        $this->db->exec('CREATE');
+    }
+
+    public function testExecWillRejectWhenCreateUnderlyingDatabaseRejects()
+    {
+        $ex = new \RuntimeException();
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\reject($ex));
+
+        $this->loop->expects($this->never())->method('addTimer');
+
+        $promise = $this->db->exec('CREATE');
+        $promise->then(null, $this->expectCallableOnceWith($ex));
+    }
+
+    public function testExecAgainAfterPreviousExecRejectedBecauseCreateUnderlyingDatabaseRejectsWillTryToOpenDatabaseAgain()
+    {
+        $ex = new \RuntimeException();
+        $this->factory->expects($this->exactly(2))->method('open')->willReturnOnConsecutiveCalls(
+            \React\Promise\reject($ex),
+            new Promise(function () { })
+        );
+
+        $this->loop->expects($this->never())->method('addTimer');
+
+        $promise = $this->db->exec('CREATE');
+        $promise->then(null, $this->expectCallableOnceWith($ex));
+
+        $this->db->exec('CREATE');
+    }
+
+    public function testExecWillResolveWhenUnderlyingDatabaseResolvesExecAndStartIdleTimer()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\DatabaseInterface')->getMock();
+        $client->expects($this->once())->method('exec')->with('CREATE')->willReturn(\React\Promise\resolve('PONG'));
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->loop->expects($this->once())->method('addTimer')->with(60, $this->anything());
+
+        $promise = $this->db->exec('CREATE');
+        $deferred->resolve($client);
+
+        $promise->then($this->expectCallableOnceWith('PONG'));
+    }
+
+    public function testExecWillResolveWhenUnderlyingDatabaseResolvesExecAndStartIdleTimerWithIdleTimeFromOptions()
+    {
+        $this->db = new LazyDatabase(':memory:', null, ['idle' => 10.0], $this->factory, $this->loop);
+
+        $client = $this->getMockBuilder('Clue\React\SQLite\DatabaseInterface')->getMock();
+        $client->expects($this->once())->method('exec')->with('CREATE')->willReturn(\React\Promise\resolve('PONG'));
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->loop->expects($this->once())->method('addTimer')->with(10.0, $this->anything());
+
+        $promise = $this->db->exec('CREATE');
+        $deferred->resolve($client);
+
+        $promise->then($this->expectCallableOnceWith('PONG'));
+    }
+
+    public function testExecWillResolveWhenUnderlyingDatabaseResolvesExecAndNotStartIdleTimerWhenIdleOptionIsNegative()
+    {
+        $this->db = new LazyDatabase(':memory:', null, ['idle' => -1], $this->factory, $this->loop);
+
+        $client = $this->getMockBuilder('Clue\React\SQLite\DatabaseInterface')->getMock();
+        $client->expects($this->once())->method('exec')->with('CREATE')->willReturn(\React\Promise\resolve('PONG'));
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->loop->expects($this->never())->method('addTimer');
+
+        $promise = $this->db->exec('CREATE');
+        $deferred->resolve($client);
+
+        $promise->then($this->expectCallableOnceWith('PONG'));
+    }
+
+    public function testExecWillRejectWhenUnderlyingDatabaseRejectsExecAndStartIdleTimer()
+    {
+        $error = new \RuntimeException();
+        $client = $this->getMockBuilder('Clue\React\SQLite\DatabaseInterface')->getMock();
+        $client->expects($this->once())->method('exec')->with('CREATE')->willReturn(\React\Promise\reject($error));
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->loop->expects($this->once())->method('addTimer');
+
+        $promise = $this->db->exec('CREATE');
+        $deferred->resolve($client);
+
+        $promise->then(null, $this->expectCallableOnceWith($error));
+    }
+
+    public function testExecWillRejectAndNotEmitErrorOrCloseWhenFactoryRejectsUnderlyingDatabase()
+    {
+        $error = new \RuntimeException();
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->db->on('error', $this->expectCallableNever());
+        $this->db->on('close', $this->expectCallableNever());
+
+        $promise = $this->db->exec('CREATE');
+        $deferred->reject($error);
+
+        $promise->then(null, $this->expectCallableOnceWith($error));
+    }
+
+    public function testExecAfterPreviousFactoryRejectsUnderlyingDatabaseWillCreateNewUnderlyingConnection()
+    {
+        $error = new \RuntimeException();
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->exactly(2))->method('open')->willReturnOnConsecutiveCalls(
+            $deferred->promise(),
+            new Promise(function () { })
+        );
+
+        $this->db->exec('CREATE');
+        $deferred->reject($error);
+
+        $this->db->exec('CREATE');
+    }
+
+    public function testExecAfterPreviousUnderlyingDatabaseAlreadyClosedWillCreateNewUnderlyingConnection()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec'))->getMock();
+        $client->expects($this->once())->method('exec')->willReturn(\React\Promise\resolve('PONG'));
+
+        $this->factory->expects($this->exactly(2))->method('open')->willReturnOnConsecutiveCalls(
+            \React\Promise\resolve($client),
+            new Promise(function () { })
+        );
+
+        $this->db->exec('CREATE');
+        $client->emit('close');
+
+        $this->db->exec('CREATE');
+    }
+
+    public function testExecAfterCloseWillRejectWithoutCreatingUnderlyingConnection()
+    {
+        $this->factory->expects($this->never())->method('open');
+
+        $this->db->close();
+        $promise = $this->db->exec('CREATE');
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testExecAfterExecWillNotStartIdleTimerWhenFirstExecResolves()
+    {
+        $deferred = new Deferred();
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec'))->getMock();
+        $client->expects($this->exactly(2))->method('exec')->willReturnOnConsecutiveCalls(
+            $deferred->promise(),
+            new Promise(function () { })
+        );
+
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\resolve($client));
+
+        $this->loop->expects($this->never())->method('addTimer');
+
+        $this->db->exec('CREATE');
+        $this->db->exec('CREATE');
+        $deferred->resolve();
+    }
+
+    public function testExecAfterExecWillStartAndCancelIdleTimerWhenSecondExecStartsAfterFirstResolves()
+    {
+        $deferred = new Deferred();
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec'))->getMock();
+        $client->expects($this->exactly(2))->method('exec')->willReturnOnConsecutiveCalls(
+            $deferred->promise(),
+            new Promise(function () { })
+        );
+
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\resolve($client));
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $this->loop->expects($this->once())->method('addTimer')->willReturn($timer);
+        $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $this->db->exec('CREATE');
+        $deferred->resolve();
+        $this->db->exec('CREATE');
+    }
+
+    public function testExecFollowedByIdleTimerWillCloseUnderlyingConnectionWithoutCloseEvent()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec', 'close'))->getMock();
+        $client->expects($this->once())->method('exec')->willReturn(\React\Promise\resolve());
+        $client->expects($this->once())->method('close')->willReturn(\React\Promise\resolve());
+
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\resolve($client));
+
+        $timeout = null;
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $this->loop->expects($this->once())->method('addTimer')->with($this->anything(), $this->callback(function ($cb) use (&$timeout) {
+            $timeout = $cb;
+            return true;
+        }))->willReturn($timer);
+
+        $this->db->on('close', $this->expectCallableNever());
+
+        $this->db->exec('CREATE');
+
+        $this->assertNotNull($timeout);
+        $timeout();
+    }
+
+    public function testQueryWillCreateUnderlyingDatabaseAndReturnPendingPromise()
+    {
+        $promise = new Promise(function () { });
+        $this->factory->expects($this->once())->method('open')->willReturn($promise);
+
+        $this->loop->expects($this->never())->method('addTimer');
+
+        $promise = $this->db->query('CREATE');
+
+        $promise->then($this->expectCallableNever());
+    }
+
+    public function testQueryTwiceWillCreateOnceUnderlyingDatabase()
+    {
+        $promise = new Promise(function () { });
+        $this->factory->expects($this->once())->method('open')->willReturn($promise);
+
+        $this->db->query('CREATE');
+        $this->db->query('CREATE');
+    }
+
+    public function testQueryWillResolveWhenUnderlyingDatabaseResolvesQueryAndStartIdleTimer()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\DatabaseInterface')->getMock();
+        $client->expects($this->once())->method('query')->with('SELECT :id', ['id' => 42])->willReturn(\React\Promise\resolve('PONG'));
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->loop->expects($this->once())->method('addTimer')->with(60.0, $this->anything());
+
+        $promise = $this->db->query('SELECT :id', ['id' => 42]);
+        $deferred->resolve($client);
+
+        $promise->then($this->expectCallableOnceWith('PONG'));
+    }
+
+    public function testQueryWillRejectWhenUnderlyingDatabaseRejectsQueryAndStartIdleTimer()
+    {
+        $error = new \RuntimeException();
+        $client = $this->getMockBuilder('Clue\React\SQLite\DatabaseInterface')->getMock();
+        $client->expects($this->once())->method('query')->with('CREATE')->willReturn(\React\Promise\reject($error));
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->loop->expects($this->once())->method('addTimer');
+
+        $promise = $this->db->query('CREATE');
+        $deferred->resolve($client);
+
+        $promise->then(null, $this->expectCallableOnceWith($error));
+    }
+
+    public function testQueryWillRejectAndNotEmitErrorOrCloseWhenFactoryRejectsUnderlyingDatabase()
+    {
+        $error = new \RuntimeException();
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->db->on('error', $this->expectCallableNever());
+        $this->db->on('close', $this->expectCallableNever());
+
+        $promise = $this->db->query('CREATE');
+        $deferred->reject($error);
+
+        $promise->then(null, $this->expectCallableOnceWith($error));
+    }
+
+    public function testQueryAfterPreviousFactoryRejectsUnderlyingDatabaseWillCreateNewUnderlyingConnection()
+    {
+        $error = new \RuntimeException();
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->exactly(2))->method('open')->willReturnOnConsecutiveCalls(
+            $deferred->promise(),
+            new Promise(function () { })
+            );
+
+        $this->db->query('CREATE');
+        $deferred->reject($error);
+
+        $this->db->query('CREATE');
+    }
+
+    public function testQueryAfterPreviousUnderlyingDatabaseAlreadyClosedWillCreateNewUnderlyingConnection()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('query'))->getMock();
+        $client->expects($this->once())->method('query')->willReturn(\React\Promise\resolve('PONG'));
+
+        $this->factory->expects($this->exactly(2))->method('open')->willReturnOnConsecutiveCalls(
+            \React\Promise\resolve($client),
+            new Promise(function () { })
+            );
+
+        $this->db->query('CREATE');
+        $client->emit('close');
+
+        $this->db->query('CREATE');
+    }
+
+    public function testQueryAfterCloseWillRejectWithoutCreatingUnderlyingConnection()
+    {
+        $this->factory->expects($this->never())->method('open');
+
+        $this->db->close();
+        $promise = $this->db->query('CREATE');
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testQueryAfterQueryWillNotStartIdleTimerWhenFirstQueryResolves()
+    {
+        $deferred = new Deferred();
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('query'))->getMock();
+        $client->expects($this->exactly(2))->method('query')->willReturnOnConsecutiveCalls(
+            $deferred->promise(),
+            new Promise(function () { })
+            );
+
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\resolve($client));
+
+        $this->loop->expects($this->never())->method('addTimer');
+
+        $this->db->query('CREATE');
+        $this->db->query('CREATE');
+        $deferred->resolve();
+    }
+
+    public function testQueryAfterQueryWillStartAndCancelIdleTimerWhenSecondQueryStartsAfterFirstResolves()
+    {
+        $deferred = new Deferred();
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('query'))->getMock();
+        $client->expects($this->exactly(2))->method('query')->willReturnOnConsecutiveCalls(
+            $deferred->promise(),
+            new Promise(function () { })
+            );
+
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\resolve($client));
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $this->loop->expects($this->once())->method('addTimer')->willReturn($timer);
+        $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $this->db->query('CREATE');
+        $deferred->resolve();
+        $this->db->query('CREATE');
+    }
+
+    public function testQueryFollowedByIdleTimerWillCloseUnderlyingConnectionWithoutCloseEvent()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('query', 'close'))->getMock();
+        $client->expects($this->once())->method('query')->willReturn(\React\Promise\resolve());
+        $client->expects($this->once())->method('close')->willReturn(\React\Promise\resolve());
+
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\resolve($client));
+
+        $timeout = null;
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $this->loop->expects($this->once())->method('addTimer')->with($this->anything(), $this->callback(function ($cb) use (&$timeout) {
+            $timeout = $cb;
+            return true;
+        }))->willReturn($timer);
+
+        $this->db->on('close', $this->expectCallableNever());
+
+        $this->db->query('CREATE');
+
+        $this->assertNotNull($timeout);
+        $timeout();
+    }
+
+    public function testCloseWillEmitCloseEventWithoutCreatingUnderlyingDatabase()
+    {
+        $this->factory->expects($this->never())->method('open');
+
+        $this->db->on('close', $this->expectCallableOnce());
+
+        $this->db->close();
+    }
+
+    public function testCloseTwiceWillEmitCloseEventOnce()
+    {
+        $this->db->on('close', $this->expectCallableOnce());
+
+        $this->db->close();
+        $this->db->close();
+    }
+
+    public function testCloseAfterExecWillCancelUnderlyingDatabaseConnectionWhenStillPending()
+    {
+        $promise = new Promise(function () { }, $this->expectCallableOnce());
+        $this->factory->expects($this->once())->method('open')->willReturn($promise);
+
+        $this->db->exec('CREATE');
+        $this->db->close();
+    }
+
+    public function testCloseAfterExecWillEmitCloseWithoutErrorWhenUnderlyingDatabaseConnectionThrowsDueToCancellation()
+    {
+        $promise = new Promise(function () { }, function () {
+            throw new \RuntimeException('Discarded');
+        });
+        $this->factory->expects($this->once())->method('open')->willReturn($promise);
+
+        $this->db->on('error', $this->expectCallableNever());
+        $this->db->on('close', $this->expectCallableOnce());
+
+        $this->db->exec('CREATE');
+        $this->db->close();
+    }
+
+    public function testCloseAfterExecWillCloseUnderlyingDatabaseConnectionWhenAlreadyResolved()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\DatabaseInterface')->getMock();
+        $client->expects($this->once())->method('exec')->willReturn(\React\Promise\resolve());
+        $client->expects($this->once())->method('close');
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->db->exec('CREATE');
+        $deferred->resolve($client);
+        $this->db->close();
+    }
+
+    public function testCloseAfterExecWillCancelIdleTimerWhenExecIsAlreadyResolved()
+    {
+        $deferred = new Deferred();
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec', 'close'))->getMock();
+        $client->expects($this->once())->method('exec')->willReturn($deferred->promise());
+        $client->expects($this->once())->method('close');
+
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\resolve($client));
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $this->loop->expects($this->once())->method('addTimer')->willReturn($timer);
+        $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $this->db->exec('CREATE');
+        $deferred->resolve();
+        $this->db->close();
+    }
+
+    public function testCloseAfterExecRejectsWillEmitClose()
+    {
+        $deferred = new Deferred();
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec', 'close'))->getMock();
+        $client->expects($this->once())->method('exec')->willReturn($deferred->promise());
+        $client->expects($this->once())->method('close')->willReturnCallback(function () use ($client) {
+            $client->emit('close');
+        });
+
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\resolve($client));
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $this->loop->expects($this->once())->method('addTimer')->willReturn($timer);
+        $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $ref = $this->db;
+        $ref->exec('CREATE')->then(null, function () use ($ref, $client) {
+            $ref->close();
+        });
+        $ref->on('close', $this->expectCallableOnce());
+        $deferred->reject(new \RuntimeException());
+    }
+
+    public function testQuitWillCloseDatabaseIfUnderlyingConnectionIsNotPendingAndResolveImmediately()
+    {
+        $this->db->on('close', $this->expectCallableOnce());
+        $promise = $this->db->quit();
+
+        $promise->then($this->expectCallableOnce());
+    }
+
+    public function testQuitAfterQuitWillReject()
+    {
+        $this->db->quit();
+        $promise = $this->db->quit();
+
+        $promise->then(null, $this->expectCallableOnce());
+    }
+
+    public function testQuitAfterExecWillQuitUnderlyingDatabase()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\DatabaseInterface')->getMock();
+        $client->expects($this->once())->method('exec')->willReturn(\React\Promise\resolve('PONG'));
+        $client->expects($this->once())->method('quit');
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->db->exec('CREATE');
+        $deferred->resolve($client);
+        $promise = $this->db->quit();
+
+        $promise->then($this->expectCallableOnce());
+    }
+
+    public function testQuitAfterExecWillCloseDatabaseWhenUnderlyingDatabaseEmitsClose()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec', 'quit'))->getMock();
+        $client->expects($this->once())->method('exec')->willReturn(\React\Promise\resolve('PONG'));
+        $client->expects($this->once())->method('quit')->willReturn(\React\Promise\resolve());
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->db->exec('CREATE');
+        $deferred->resolve($client);
+
+        $this->db->on('close', $this->expectCallableOnce());
+        $promise = $this->db->quit();
+
+        $client->emit('close');
+        $promise->then($this->expectCallableOnce());
+    }
+
+    public function testEmitsNoErrorEventWhenUnderlyingDatabaseEmitsError()
+    {
+        $error = new \RuntimeException();
+
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec'))->getMock();
+        $client->expects($this->once())->method('exec')->willReturn(\React\Promise\resolve());
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->db->exec('CREATE');
+        $deferred->resolve($client);
+
+        $this->db->on('error', $this->expectCallableNever());
+        $client->emit('error', array($error));
+    }
+
+    public function testEmitsNoCloseEventWhenUnderlyingDatabaseEmitsClose()
+    {
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec'))->getMock();
+        $client->expects($this->once())->method('exec')->willReturn(\React\Promise\resolve());
+
+        $deferred = new Deferred();
+        $this->factory->expects($this->once())->method('open')->willReturn($deferred->promise());
+
+        $this->db->exec('CREATE');
+        $deferred->resolve($client);
+
+        $this->db->on('close', $this->expectCallableNever());
+        $client->emit('close');
+    }
+
+    public function testEmitsNoCloseEventButWillCancelIdleTimerWhenUnderlyingConnectionEmitsCloseAfterExecIsAlreadyResolved()
+    {
+        $deferred = new Deferred();
+        $client = $this->getMockBuilder('Clue\React\SQLite\Io\ProcessIoDatabase')->disableOriginalConstructor()->setMethods(array('exec'))->getMock();
+        $client->expects($this->once())->method('exec')->willReturn($deferred->promise());
+
+        $this->factory->expects($this->once())->method('open')->willReturn(\React\Promise\resolve($client));
+
+        $timer = $this->getMockBuilder('React\EventLoop\TimerInterface')->getMock();
+        $this->loop->expects($this->once())->method('addTimer')->willReturn($timer);
+        $this->loop->expects($this->once())->method('cancelTimer')->with($timer);
+
+        $this->db->on('close', $this->expectCallableNever());
+
+        $this->db->exec('CREATE');
+        $deferred->resolve();
+
+        $client->emit('close');
+    }
+
+    protected function expectCallableNever()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->never())
+            ->method('__invoke');
+
+        return $mock;
+    }
+
+    protected function expectCallableOnce()
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke');
+
+        return $mock;
+    }
+
+    protected function expectCallableOnceWith($value)
+    {
+        $mock = $this->createCallableMock();
+        $mock
+            ->expects($this->once())
+            ->method('__invoke')
+            ->with($value);
+
+        return $mock;
+    }
+
+    protected function createCallableMock()
+    {
+        return $this->getMockBuilder('stdClass')->setMethods(array('__invoke'))->getMock();
+    }
+}

--- a/tests/Io/ProcessIoDatabaseTest.php
+++ b/tests/Io/ProcessIoDatabaseTest.php
@@ -4,7 +4,7 @@ use PHPUnit\Framework\TestCase;
 use Clue\React\SQLite\DatabaseInterface;
 use React\Stream\ThroughStream;
 
-class DatabaseTest extends TestCase
+class ProcessIoDatabaseTest extends TestCase
 {
     public function testDatabaseWillEmitErrorWhenStdoutReportsNonNdjsonStream()
     {


### PR DESCRIPTION
Builds on top of clue/reactphp-redis#87 and friends-of-reactphp/mysql#87 and others.

Resolves #2 