### PR TITLE
Fix result set rows for DDL queries to be null, instead of empty array

### DIFF
--- a/res/sqlite-worker.php
+++ b/res/sqlite-worker.php
@@ -172,16 +172,15 @@ $in->on('data', function ($data) use (&$db, $in, $out) {
                 'error' => array('message' => $db->lastErrorMsg())
             ));
         } else {
-            $columns = array();
-            for ($i = 0, $n = $result->numColumns(); $i < $n; ++$i) {
-                $columns[] = $result->columnName($i);
-            }
-
-            $rows = array();
             if ($result->numColumns() !== 0) {
                 // Fetch all rows only if this result set has any columns.
                 // INSERT/UPDATE/DELETE etc. do not return any columns, trying
                 // to fetch the results here will issue the same query again.
+                $rows = $columns = [];
+                for ($i = 0, $n = $result->numColumns(); $i < $n; ++$i) {
+                    $columns[] = $result->columnName($i);
+                }
+
                 while (($row = $result->fetchArray(\SQLITE3_ASSOC)) !== false) {
                     // base64-encode any string that is not valid UTF-8 without control characters (BLOB)
                     foreach ($row as &$value) {
@@ -193,6 +192,8 @@ $in->on('data', function ($data) use (&$db, $in, $out) {
                     }
                     $rows[] = $row;
                 }
+            } else {
+                $rows = $columns = null;
             }
             $result->finalize();
 

--- a/src/Io/ProcessIoDatabase.php
+++ b/src/Io/ProcessIoDatabase.php
@@ -90,18 +90,19 @@ class ProcessIoDatabase extends EventEmitter implements DatabaseInterface
             $result->changed = $data['changed'];
             $result->insertId = $data['insertId'];
             $result->columns = $data['columns'];
+            $result->rows = $data['rows'];
 
             // base64-decode string result values for BLOBS
-            $result->rows = [];
-            foreach ($data['rows'] as $row) {
-                foreach ($row as &$value) {
-                    if (isset($value['base64'])) {
-                        $value = \base64_decode($value['base64']);
-                    } elseif (isset($value['float'])) {
-                        $value = (float)$value['float'];
+            if ($result->rows !== null) {
+                foreach ($result->rows as &$row) {
+                    foreach ($row as &$value) {
+                        if (isset($value['base64'])) {
+                            $value = \base64_decode($value['base64']);
+                        } elseif (isset($value['float'])) {
+                            $value = (float)$value['float'];
+                        }
                     }
                 }
-                $result->rows[] = $row;
             }
 
             return $result;


### PR DESCRIPTION
The result set for DDL queries (INSERT, UPDATE, DELETE etc.) is empty,
i.e. it does not contain any columns or rows. Columns and rows should
thus be represented by a null value. In contrast, an empty result set
from a SELECT query will always contain a non-empty array of columns and
may contain any number of rows (possibly an empty array of rows).

Builds on top of #20 