### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,7 @@ existing SQLite database file (or automatically create it on first run) and then
 `INSERT` a new record to the database:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Clue\React\SQLite\Factory($loop);
+$factory = new Clue\React\SQLite\Factory();
 
 $db = $factory->openLazy('users.db');
 $db->exec('CREATE TABLE IF NOT EXISTS foo (id INTEGER PRIMARY KEY AUTOINCREMENT, bar STRING)');
@@ -78,8 +77,6 @@ $db->query('INSERT INTO foo (bar) VALUES (?)', [$name])->then(
 );
 
 $db->quit();
-
-$loop->run();
 ```
 
 See also the [examples](examples).
@@ -89,12 +86,16 @@ See also the [examples](examples).
 ### Factory
 
 The `Factory` is responsible for opening your [`DatabaseInterface`](#databaseinterface) instance.
-It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$factory = new Clue\React\SQLite\Factory($loop);
+$factory = new Clue\React\SQLite\Factory();
 ```
+
+This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+pass the event loop instance to use for this object. You can use a `null` value
+here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+This value SHOULD NOT be given unless you're sure you want to explicitly use a
+given event loop instance.
 
 #### open()
 

--- a/composer.json
+++ b/composer.json
@@ -10,21 +10,21 @@
             "email": "christian@clue.engineering"
         }
     ],
-    "autoload": {
-        "psr-4": { "Clue\\React\\SQLite\\": "src/" }
-    },
-    "autoload-dev": {
-        "psr-4": { "Clue\\Tests\\React\\SQLite\\": "tests/" }
-    },
     "require": {
         "php": ">=5.4",
         "ext-sqlite3": "*",
         "clue/ndjson-react": "^1.0",
         "react/child-process": "^0.6",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "^1.2",
         "react/promise": "^2.7 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.3 || ^5.7 || ^4.8.35"
+    },
+    "autoload": {
+        "psr-4": { "Clue\\React\\SQLite\\": "src/" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Clue\\Tests\\React\\SQLite\\": "tests/" }
     }
 }

--- a/examples/insert.php
+++ b/examples/insert.php
@@ -5,8 +5,7 @@ use Clue\React\SQLite\Result;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $n = isset($argv[1]) ? $argv[1] : 1;
 $db = $factory->openLazy('test.db');
@@ -21,5 +20,3 @@ for ($i = 0; $i < $n; ++$i) {
 }
 
 $db->quit();
-
-$loop->run();

--- a/examples/search.php
+++ b/examples/search.php
@@ -6,8 +6,7 @@ use Clue\React\SQLite\Result;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$factory = new Factory($loop);
+$factory = new Factory();
 
 $search = isset($argv[1]) ? $argv[1] : 'foo';
 $db = $factory->openLazy('test.db');
@@ -20,5 +19,3 @@ $db->query('SELECT * FROM foo WHERE bar LIKE ?', ['%' . $search . '%'])->then(fu
     }
 }, 'printf');
 $db->quit();
-
-$loop->run();

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -5,30 +5,37 @@ namespace Clue\React\SQLite;
 use Clue\React\SQLite\Io\LazyDatabase;
 use Clue\React\SQLite\Io\ProcessIoDatabase;
 use React\ChildProcess\Process;
+use React\EventLoop\Loop;
 use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use React\Stream\DuplexResourceStream;
 
 class Factory
 {
+    /** @var LoopInterface */
     private $loop;
+
     private $bin = PHP_BINARY;
     private $useSocket;
 
     /**
      * The `Factory` is responsible for opening your [`DatabaseInterface`](#databaseinterface) instance.
-     * It also registers everything with the main [`EventLoop`](https://github.com/reactphp/event-loop#usage).
      *
      * ```php
-     * $loop = \React\EventLoop\Factory::create();
-     * $factory = new Factory($loop);
+     * $factory = new Clue\React\SQLite\Factory();
      * ```
      *
-     * @param LoopInterface $loop
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
+     *
+     * @param ?LoopInterface $loop
      */
-    public function __construct(LoopInterface $loop)
+    public function __construct(LoopInterface $loop = null)
     {
-        $this->loop = $loop;
+        $this->loop = $loop ?: Loop::get();
 
         // use socket I/O for Windows only, use faster process pipes everywhere else
         $this->useSocket = DIRECTORY_SEPARATOR === '\\';


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$factory = new Clue\React\SQLite\Factory($loop);

// new (using default loop)
$factory = new Clue\React\SQLite\Factory();
```

Builds on top of https://github.com/reactphp/event-loop/pull/226, https://github.com/reactphp/event-loop/pull/229 and https://github.com/reactphp/event-loop/pull/232