### PR TITLE
Reject null byte in path to SQLite database file

### DIFF
--- a/res/sqlite-worker.php
+++ b/res/sqlite-worker.php
@@ -90,6 +90,11 @@ $in->on('data', function ($data) use (&$db, $in, $out) {
                 'id' => $data->id,
                 'error' => array('message' => $e->getMessage())
             ));
+        } catch (Error $e) {
+            $out->write(array(
+                'id' => $data->id,
+                'error' => array('message' => $e->getMessage())
+            ));
         }
     } elseif ($data->method === 'open' && \count($data->params) === 2 && \is_string($data->params[0]) && \is_int($data->params[1])) {
         // open database with two parameters: $filename, $flags
@@ -104,6 +109,11 @@ $in->on('data', function ($data) use (&$db, $in, $out) {
                 'result' => true
             ));
         } catch (Exception $e) {
+            $out->write(array(
+                'id' => $data->id,
+                'error' => array('message' => $e->getMessage())
+            ));
+        } catch (Error $e) {
             $out->write(array(
                 'id' => $data->id,
                 'error' => array('message' => $e->getMessage())

--- a/tests/FunctionalDatabaseTest.php
+++ b/tests/FunctionalDatabaseTest.php
@@ -138,6 +138,29 @@ class FunctionalDatabaseTest extends TestCase
      * @dataProvider provideSocketFlags
      * @param bool $flag
      */
+    public function testOpenInvalidPathWithNullByteRejects($flag)
+    {
+        $loop = \React\EventLoop\Factory::create();
+        $factory = new Factory($loop);
+
+        $ref = new \ReflectionProperty($factory, 'useSocket');
+        $ref->setAccessible(true);
+        $ref->setValue($factory, $flag);
+
+        $promise = $factory->open("test\0.db");
+
+        $promise->then(
+            null,
+            $this->expectCallableOnceWith($this->isInstanceOf('RuntimeException'))
+        );
+
+        $loop->run();
+    }
+
+    /**
+     * @dataProvider provideSocketFlags
+     * @param bool $flag
+     */
     public function testOpenInvalidFlagsRejects($flag)
     {
         $loop = \React\EventLoop\Factory::create();


### PR DESCRIPTION
When writing a null byte inside your file path to your SQLite database it's possible to receive an `TypeError` (for PHP >= 7) in return.
For older PHP versions we're already handling the thrown `Exception`.