### PR TITLE
Support passing custom PHP binary as optional argument to `Factory`

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,18 @@ here in order to use the [default loop](https://github.com/reactphp/event-loop#l
 This value SHOULD NOT be given unless you're sure you want to explicitly use a
 given event loop instance.
 
+This class takes an optional `?string $binary` parameter that can be used to
+pass a custom PHP binary to use when spawning a child process. You can use a
+`null` value here in order to automatically detect the current PHP binary. You
+may want to pass a custom executable path if this automatic detection fails or
+if you explicitly want to run the child process with a different PHP version or
+environment than your parent process.
+
+```php
+// advanced usage: pass custom PHP binary to use when spawning child process
+$factory = new Clue\React\SQLite\Factory(null, '/usr/bin/php6.0');
+```
+
 #### open()
 
 The `open(string $filename, int $flags = null): PromiseInterface<DatabaseInterface>` method can be used to

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -7,6 +7,31 @@ use Clue\React\SQLite\Factory;
 
 class FactoryTest extends TestCase
 {
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $factory = new Factory();
+
+        $ref = new \ReflectionProperty($factory, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($factory);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
+    public function testConstructWitLoopAndBinaryAssignsBothVariables()
+    {
+        $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();
+        $factory = new Factory($loop, 'php6.0');
+
+        $ref = new \ReflectionProperty($factory, 'loop');
+        $ref->setAccessible(true);
+        $this->assertSame($loop, $ref->getValue($factory));
+
+        $ref = new \ReflectionProperty($factory, 'bin');
+        $ref->setAccessible(true);
+        $this->assertSame('php6.0', $ref->getValue($factory));
+    }
+
     public function testLoadLazyReturnsDatabaseImmediately()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/FunctionalFactoryTest.php
+++ b/tests/FunctionalFactoryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Clue\Tests\React\SQLite;
+
+use Clue\React\SQLite\DatabaseInterface;
+use Clue\React\SQLite\Factory;
+use PHPUnit\Framework\TestCase;
+use React\EventLoop\Loop;
+
+class FunctionalFactoryTest extends TestCase
+{
+    public function testOpenReturnsPromiseWhichFulfillsWithConnectionForMemoryPath()
+    {
+        $factory = new Factory();
+        $promise = $factory->open(':memory:');
+
+        $promise->then(function (DatabaseInterface $db) {
+            echo 'open.';
+            $db->on('close', function () {
+                echo 'close.';
+            });
+
+            $db->close();
+        }, function (\Exception $e) {
+            echo 'Error: ' . $e->getMessage() . PHP_EOL;
+        });
+
+        $this->expectOutputString('open.close.');
+        Loop::run();
+    }
+
+    public function testOpenReturnsPromiseWhichFulfillsWithConnectionForMemoryPathAndExplicitPhpBinary()
+    {
+        $factory = new Factory(null, PHP_BINARY);
+        $promise = $factory->open(':memory:');
+
+        $promise->then(function (DatabaseInterface $db) {
+            echo 'open.';
+            $db->on('close', function () {
+                echo 'close.';
+            });
+
+                $db->close();
+        }, function (\Exception $e) {
+            echo 'Error: ' . $e->getMessage() . PHP_EOL;
+        });
+
+        $this->expectOutputString('open.close.');
+        Loop::run();
+    }
+
+    public function testOpenReturnsPromiseWhichRejectsWithExceptionWhenPathIsInvalid()
+    {
+        $factory = new Factory();
+        $promise = $factory->open('/dev/foobar');
+
+        $promise->then(function (DatabaseInterface $db) {
+            echo 'open.';
+            $db->close();
+        }, function (\Exception $e) {
+            echo 'Error: ' . $e->getMessage() . PHP_EOL;
+        });
+
+        $this->expectOutputString('Error: Unable to open database: unable to open database file' . PHP_EOL);
+        Loop::run();
+    }
+
+    public function testOpenReturnsPromiseWhichRejectsWithExceptionWhenExplicitPhpBinaryExitsImmediately()
+    {
+        $factory = new Factory(null, 'echo');
+
+        $ref = new \ReflectionProperty($factory, 'useSocket');
+        $ref->setAccessible(true);
+        $ref->setValue($factory, true);
+
+        $promise = $factory->open(':memory:');
+
+        $promise->then(function (DatabaseInterface $db) {
+            echo 'open.';
+            $db->close();
+        }, function (\Exception $e) {
+            echo 'Error: ' . $e->getMessage() . PHP_EOL;
+        });
+
+        $this->expectOutputString('Error: No connection detected' . PHP_EOL);
+        Loop::run();
+    }
+}


### PR DESCRIPTION
This changeset adds support for passing a custom PHP binary as an optional argument to the `Factory`.

```php
// advanced usage: pass custom PHP binary to use when spawning child process
$factory = new Clue\React\SQLite\Factory(null, '/usr/bin/php6.0');
```

Refs #35