### PR TITLE
Support running from PHAR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,4 +36,8 @@ jobs:
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
       - run: cd tests/install-as-dep && composer install && php query.php
-      - run: cd tests/install-as-dep && php -d phar.readonly=0 vendor/bin/phar-composer build . query.phar && php query.phar
+      - run: cd tests/install-as-dep && php -d phar.readonly=0 vendor/bin/phar-composer build . query.phar
+        continue-on-error: ${{ matrix.os == 'windows-2019' }}
+        id: phar
+      - run: php tests/install-as-dep/query.phar
+        if: ${{ steps.phar.outcome == 'success' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,4 @@ jobs:
         if: ${{ matrix.php >= 7.3 }}
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
+      - run: cd tests/install-as-dep && composer install && php query.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,3 +36,4 @@ jobs:
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
       - run: cd tests/install-as-dep && composer install && php query.php
+      - run: cd tests/install-as-dep && php -d phar.readonly=0 vendor/bin/phar-composer build . query.phar && php query.phar

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,6 +9,7 @@
     <testsuites>
         <testsuite name="SQLite React Test Suite">
             <directory>./tests/</directory>
+            <exclude>./tests/install-as-dep/</exclude>
         </testsuite>
     </testsuites>
     <coverage>

--- a/phpunit.xml.legacy
+++ b/phpunit.xml.legacy
@@ -8,6 +8,7 @@
     <testsuites>
         <testsuite name="SQLite React Test Suite">
             <directory>./tests/</directory>
+            <exclude>./tests/install-as-dep/</exclude>
         </testsuite>
     </testsuites>
     <filter>

--- a/tests/install-as-dep/.gitignore
+++ b/tests/install-as-dep/.gitignore
@@ -1,0 +1,2 @@
+/composer.lock
+/vendor/

--- a/tests/install-as-dep/.gitignore
+++ b/tests/install-as-dep/.gitignore
@@ -1,2 +1,3 @@
 /composer.lock
+/query.phar
 /vendor/

--- a/tests/install-as-dep/composer.json
+++ b/tests/install-as-dep/composer.json
@@ -2,10 +2,19 @@
     "require": {
         "clue/reactphp-sqlite": "*@dev"
     },
+    "require-dev": {
+        "clue/phar-composer": "^1.0"
+    },
+    "bin": [
+        "query.php"
+    ],
     "repositories": [
         {
             "type": "path",
-            "url": "../../"
+            "url": "../../",
+            "options": {
+                "symlink": false
+            }
         }
     ]
 }

--- a/tests/install-as-dep/composer.json
+++ b/tests/install-as-dep/composer.json
@@ -1,0 +1,11 @@
+{
+    "require": {
+        "clue/reactphp-sqlite": "*@dev"
+    },
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../../"
+        }
+    ]
+}

--- a/tests/install-as-dep/query.php
+++ b/tests/install-as-dep/query.php
@@ -1,0 +1,26 @@
+<?php
+
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require __DIR__ . '/vendor/autoload.php';
+} else {
+    require __DIR__ . '/../../vendor/autoload.php';
+}
+
+$factory = new Clue\React\SQLite\Factory();
+$db = $factory->openLazy(':memory:', null, ['idle' => 0.001]);
+
+$query = isset($argv[1]) ? $argv[1] : 'SELECT 42 AS value';
+$args = array_slice(isset($argv) ? $argv : [], 2);
+
+$db->query('SELECT ? AS answer', [42])->then(function (Clue\React\SQLite\Result $result) {
+    if ($result->columns !== ['answer'] || count($result->rows) !== 1 || $result->rows[0]['answer'] !== 42) {
+        var_dump($result);
+        throw new RuntimeException('Unexpected result');
+    }
+
+    $answer = $result->rows[0]['answer'];
+    echo 'Answer: ' . $answer . PHP_EOL;
+})->then(null, function (Exception $e) {
+    echo 'Error: ' . $e->getMessage() . PHP_EOL;
+    exit(1);
+});


### PR DESCRIPTION
This changeset adds support for running from PHARs. This works out of the box without any special configuration by running the SQLite worker like this internally:

```php
$ php -r 'require("phar:///home/alice/Desktop/acme.phar/vendor/clue/reactphp-sqlite/res/sqlite-worker.php");'
```

The updated test suite confirms this works across all supported platforms, including Windows (which requires some special care). Windows tests on PHP < 7.3 may currently be skipped because building the PHAR fails due to https://github.com/clue/phar-composer/issues/116, but execution should work just fine in either case.

Resolves / closes #5
Builds on top of #50, #45, https://github.com/clue/phar-composer/pull/123 and others