### PR TITLE
Update test suite & clue/phar-composer to avoid skipped tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   PHPUnit:
+    name: PHPUnit (PHP ${{ matrix.php }} on ${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -25,19 +26,15 @@ jobs:
           - 5.4
     steps:
       - uses: actions/checkout@v2
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
           extensions: sqlite3
+          coverage: xdebug
       - run: composer install
       - run: vendor/bin/phpunit --coverage-text
         if: ${{ matrix.php >= 7.3 }}
       - run: vendor/bin/phpunit --coverage-text -c phpunit.xml.legacy
         if: ${{ matrix.php < 7.3 }}
       - run: cd tests/install-as-dep && composer install && php query.php
-      - run: cd tests/install-as-dep && php -d phar.readonly=0 vendor/bin/phar-composer build . query.phar
-        continue-on-error: ${{ matrix.os == 'windows-2019' }}
-        id: phar
-      - run: php tests/install-as-dep/query.phar
-        if: ${{ steps.phar.outcome == 'success' }}
+      - run: cd tests/install-as-dep && php -d phar.readonly=0 vendor/bin/phar-composer build . query.phar && php query.phar

--- a/tests/install-as-dep/composer.json
+++ b/tests/install-as-dep/composer.json
@@ -3,7 +3,7 @@
         "clue/reactphp-sqlite": "*@dev"
     },
     "require-dev": {
-        "clue/phar-composer": "^1.0"
+        "clue/phar-composer": "^1.4"
     },
     "bin": [
         "query.php"


### PR DESCRIPTION
The updated test suite now confirms executing from a PHP archives (PHAR) works across all supported platforms, including Windows (which requires some special care).

Builds on top of #55, https://github.com/clue/phar-composer/pull/129, https://github.com/clue/phar-composer/pull/130, and referenced tickets
Builds on top of #13 and #55 for special Windows support
Refs #5 for improved PHAR support