### PR TITLE
Support spawning worker process from within PHARs without file extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,3 +38,5 @@ jobs:
         if: ${{ matrix.php < 7.3 }}
       - run: cd tests/install-as-dep && composer install && php query.php
       - run: cd tests/install-as-dep && php -d phar.readonly=0 vendor/bin/phar-composer build . query.phar && php query.phar
+      - run: cd tests/install-as-dep && mv query.phar query.ext && php query.ext
+      - run: cd tests/install-as-dep && mv query.ext query && php query

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -229,8 +229,8 @@ class Factory
         $cwd = null;
         $worker = \dirname(__DIR__) . '/res/sqlite-worker.php';
 
-        if (\class_exists('Phar', false) && \Phar::running(false) !== '') {
-            $worker = '-r' . 'require(' . \var_export($worker, true) . ');'; // @codeCoverageIgnore
+        if (\class_exists('Phar', false) && ($phar = \Phar::running(false)) !== '') {
+            $worker = '-r' . 'Phar::loadPhar(' . var_export($phar, true) . ');require(' . \var_export($worker, true) . ');'; // @codeCoverageIgnore
         } else {
             $cwd = __DIR__ . '/../res';
             $worker = \basename($worker);
@@ -297,8 +297,8 @@ class Factory
         $cwd = null;
         $worker = \dirname(__DIR__) . '/res/sqlite-worker.php';
 
-        if (\class_exists('Phar', false) && \Phar::running(false) !== '') {
-            $worker = '-r' . 'require(' . \var_export($worker, true) . ');'; // @codeCoverageIgnore
+        if (\class_exists('Phar', false) && ($phar = \Phar::running(false)) !== '') {
+            $worker = '-r' . 'Phar::loadPhar(' . var_export($phar, true) . ');require(' . \var_export($worker, true) . ');'; // @codeCoverageIgnore
         } else {
             $cwd = __DIR__ . '/../res';
             $worker = \basename($worker);

--- a/tests/install-as-dep/.gitignore
+++ b/tests/install-as-dep/.gitignore
@@ -1,3 +1,5 @@
 /composer.lock
+/query
+/query.ext
 /query.phar
 /vendor/


### PR DESCRIPTION
This changeset adds support for running from PHARs without a file extension. This is particularly common when installing PHARs as system binaries on Unix-like platforms.

While the `phar://` stream wrapper is wonderful, PHP exhibits some (afaict undocumented) behavior when it comes to PHARs with no file extension. I've written a more in-depth explanation on Twitter (https://twitter.com/another_clue/status/1493175007484301317), but the gist is that we can avoid this shortcoming by using an alias for the PHAR by first loading it. This now works out of the box without any special configuration by running the SQLite worker like this internally:

```diff
- $ php -r 'require("phar:///home/alice/Desktop/acme.phar/vendor/clue/reactphp-sqlite/res/sqlite-worker.php");'
+ $ php -r 'Phar::loadPhar("/home/alice/Desktop/acme.phar");require("phar:///home/alice/Desktop/acme.phar/vendor/clue/reactphp-sqlite/res/sqlite-worker.php");'
```

The updated test suite confirms this works across all supported platforms, including Windows (which requires some special care via #60).

Builds on top of #60 and #55. Together with the referenced tickets and the upstream fixes required to get this in, you're looking at several days worth of debugging and toying around with different approaches to distill this to this minimal fix that works across all supported platforms. The underlying behavior is mostly undocumented in PHP afaict, so I'm quite happy with the resulting changeset.
Refs #5 for the underlying feature request.