### PR TITLE
Update test suite to remove deprecated `utf8_decode()` in preparation for PHP 8.2

### DIFF
--- a/tests/FunctionalDatabaseTest.php
+++ b/tests/FunctionalDatabaseTest.php
@@ -480,7 +480,7 @@ class FunctionalDatabaseTest extends TestCase
             ['hello', 'TEXT'],
             ['hellö', 'TEXT'],
             ["hello\tworld\r\n", 'TEXT'],
-            [utf8_decode('hello wörld!'), 'BLOB'],
+            ["hello w\xF6rld!", 'BLOB'],
             ["hello\x7fö", 'BLOB'],
             ["\x03\x02\x001", 'BLOB'],
             ["a\000b", 'BLOB']

--- a/tests/Io/BlockingDatabaseTest.php
+++ b/tests/Io/BlockingDatabaseTest.php
@@ -109,7 +109,7 @@ class BlockingDatabaseTest extends TestCase
             ['hello', 'TEXT'],
             ['hellö', 'TEXT'],
             ["hello\tworld\r\n", 'TEXT'],
-            [utf8_decode('hello wörld!'), 'BLOB'],
+            ["hello w\xF6rld!", 'BLOB'],
             ["hello\x7fö", 'BLOB'],
             ["\x03\x02\x001", 'BLOB'],
             ["a\000b", 'BLOB']


### PR DESCRIPTION
The two methods `utf8_encode()` and `utf8_decode()` will be marked as deprecated in PHP 8.2, will raise a standard E_DEPRECATED diagnostic, and will be removed in PHP 9. The tests now use the string that would ultimately come from `utf8_decode()`, I don't expect that to change in the future due to the standardization of UTF8 and ISO 8859-1 (Latin-1).