### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,9 +14,9 @@
         "php": ">=5.4",
         "ext-sqlite3": "*",
         "clue/ndjson-react": "^1.0",
-        "react/child-process": "^0.6",
+        "react/child-process": "^0.6.6",
         "react/event-loop": "^1.2",
-        "react/promise": "^3 || ^2.7 || ^1.2.1"
+        "react/promise": "^3.2 || ^2.7 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"

--- a/src/Factory.php
+++ b/src/Factory.php
@@ -62,8 +62,12 @@ class Factory
      * @param ?LoopInterface $loop
      * @param ?string $binary
      */
-    public function __construct(LoopInterface $loop = null, $binary = null)
+    public function __construct($loop = null, $binary = null)
     {
+        if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+            throw new \InvalidArgumentException('Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+        }
+
         $this->loop = $loop ?: Loop::get();
         $this->bin = $binary === null ? $this->php() : $binary;
 

--- a/tests/FactoryTest.php
+++ b/tests/FactoryTest.php
@@ -32,6 +32,20 @@ class FactoryTest extends TestCase
         $this->assertSame('php6.0', $ref->getValue($factory));
     }
 
+    public function testCtorThrowsForInvalidLoop()
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException('InvalidArgumentException');
+            $this->expectExceptionMessage('Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+        } else {
+            // legacy PHPUnit
+            $this->setExpectedException('InvalidArgumentException', 'Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+        }
+
+        new Factory('loop');
+    }
+
     public function testLoadLazyReturnsDatabaseImmediately()
     {
         $loop = $this->getMockBuilder('React\EventLoop\LoopInterface')->getMock();

--- a/tests/Io/BlockingDatabaseTest.php
+++ b/tests/Io/BlockingDatabaseTest.php
@@ -9,8 +9,10 @@ class BlockingDatabaseTest extends TestCase
     public function testCtorThrowsForInvalidPath()
     {
         if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
             $this->expectException('Exception');
         } else {
+            // legacy PHPUnit
             $this->setExpectedException('Exception');
         }
         new BlockingDatabase('/dev/foobar');


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v1 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

Builds on top of #71, #64, #39, https://github.com/reactphp/promise/pull/260 and https://github.com/reactphp/child-process/pull/114
Resolves / closes #69 